### PR TITLE
1.4.0 Messi: Team Games Support

### DIFF
--- a/lib/core/utils/version_story.dart
+++ b/lib/core/utils/version_story.dart
@@ -20,7 +20,7 @@ class ScoreEaseVersionStory {
   static Map<String, ScoreEaseVersionStory> versionStoryMap = {
     "5": ScoreEaseVersionStory(
       versionSemantic: "1.4.0",
-      versionName: "Bumrah",
+      versionName: "Messi",
       buildNumber: "5",
       buildDate: "TBD",
       tagline: "Unplayable team dynamics.",

--- a/lib/core/widgets/password_prompt_widget.dart
+++ b/lib/core/widgets/password_prompt_widget.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:scoreease/core/utils/theme.dart';
 import 'package:scoreease/core/utils/security_helper.dart';
@@ -71,185 +70,241 @@ class _PasswordPromptWidgetState extends State<PasswordPromptWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final isDesktop = size.width > 600;
+
     return Scaffold(
       backgroundColor: appColors.screenBg,
       body: Stack(
+        fit: StackFit.expand,
         children: [
-          // Decorative background blur elements
+          // Premium Mesh Gradient Background
           Positioned(
-            top: -100,
-            right: -50,
+            top: -size.height * 0.2,
+            right: -size.width * 0.2,
             child: Container(
-              width: 300,
-              height: 300,
+              width: size.width * 0.8,
+              height: size.width * 0.8,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: appColors.primaryColor.withValues(alpha: 0.1),
+                gradient: RadialGradient(
+                  colors: [
+                    appColors.primaryColor.withValues(alpha: 0.15),
+                    Colors.transparent,
+                  ],
+                ),
               ),
-            ).animate().fade(duration: 1000.ms).scale(begin: const Offset(0.8, 0.8)),
+            ).animate().fade(duration: 1500.ms).scale(begin: const Offset(0.8, 0.8)),
           ),
           Positioned(
-            bottom: -50,
-            left: -100,
+            bottom: -size.height * 0.2,
+            left: -size.width * 0.1,
             child: Container(
-              width: 250,
-              height: 250,
+              width: size.width * 0.6,
+              height: size.width * 0.6,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: appColors.primaryColor.withValues(alpha: 0.05),
+                gradient: RadialGradient(
+                  colors: [
+                    Colors.purpleAccent.withValues(alpha: 0.1),
+                    Colors.transparent,
+                  ],
+                ),
               ),
-            ).animate().fade(duration: 1200.ms).scale(begin: const Offset(0.8, 0.8)),
+            ).animate().fade(duration: 1800.ms).scale(begin: const Offset(0.8, 0.8)),
+          ),
+          
+          // Full-screen subtle blur
+          BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+            child: Container(color: Colors.transparent),
           ),
           
           Center(
             child: SingleChildScrollView(
-              padding: EdgeInsets.all(24.w),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(24.r),
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                  child: Container(
-                    width: double.infinity,
-                    constraints: BoxConstraints(maxWidth: 400.w),
-                    padding: EdgeInsets.all(32.w),
-                    decoration: BoxDecoration(
-                      color: appColors.tileBgColor.withValues(alpha: 0.85),
-                      borderRadius: BorderRadius.circular(24.r),
-                      border: Border.all(
-                        color: appColors.primaryColor.withValues(alpha: 0.2),
-                        width: 1,
+              padding: EdgeInsets.all(isDesktop ? 32.0 : 24.0),
+              child: Container(
+                width: double.infinity,
+                constraints: const BoxConstraints(maxWidth: 420),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(32),
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+                    child: Container(
+                      padding: EdgeInsets.all(isDesktop ? 40.0 : 32.0),
+                      decoration: BoxDecoration(
+                        color: appColors.tileBgColor.withValues(alpha: 0.7),
+                        borderRadius: BorderRadius.circular(32),
+                        border: Border.all(
+                          color: Colors.white.withValues(alpha: 0.15),
+                          width: 1.5,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.1),
+                            blurRadius: 30,
+                            offset: const Offset(0, 15),
+                          ),
+                        ],
                       ),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.05),
-                          blurRadius: 20,
-                          offset: const Offset(0, 10),
-                        ),
-                      ],
-                    ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        // Icon with dynamic state
-                        Container(
-                          padding: EdgeInsets.all(16.w),
-                          decoration: BoxDecoration(
-                            color: _isUnlocked 
-                                ? Colors.green.withValues(alpha: 0.1) 
-                                : appColors.primaryColor.withValues(alpha: 0.1),
-                            shape: BoxShape.circle,
-                          ),
-                          child: Icon(
-                            _isUnlocked ? Icons.lock_open_rounded : Icons.lock_outline_rounded,
-                            size: 48.w,
-                            color: _isUnlocked ? Colors.green : appColors.primaryColor,
-                          )
-                          .animate(target: _isUnlocked ? 1 : 0)
-                          .scale(end: const Offset(1.2, 1.2))
-                          .tint(color: Colors.green),
-                        ).animate(onPlay: (controller) => controller.repeat(reverse: true))
-                         .shimmer(duration: 2000.ms, color: appColors.primaryColor.withValues(alpha: 0.2)),
-                        
-                        SizedBox(height: 24.h),
-                        Text(
-                          widget.title,
-                          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                                fontWeight: FontWeight.bold,
-                              ),
-                          textAlign: TextAlign.center,
-                        ),
-                        SizedBox(height: 8.h),
-                        Text(
-                          widget.message,
-                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                color: Theme.of(context).hintColor,
-                                height: 1.5,
-                              ),
-                          textAlign: TextAlign.center,
-                        ),
-                        SizedBox(height: 32.h),
-                        
-                        // Password Input
-                        TextField(
-                          controller: _controller,
-                          focusNode: _focusNode,
-                          obscureText: true,
-                          textAlign: TextAlign.center,
-                          style: TextStyle(fontSize: 20.sp, letterSpacing: 4.0),
-                          decoration: InputDecoration(
-                            labelText: "Password",
-                            labelStyle: TextStyle(letterSpacing: 0, fontSize: 14.sp),
-                            errorText: _errorText,
-                            errorStyle: const TextStyle(letterSpacing: 0),
-                            filled: true,
-                            fillColor: appColors.inputBgFill.withValues(alpha: 0.5),
-                            border: appColors.textInputEnabledBorder,
-                            enabledBorder: appColors.textInputEnabledBorder,
-                            focusedBorder: appColors.textInputFocusedBorder,
-                            contentPadding: EdgeInsets.symmetric(vertical: 16.h, horizontal: 20.w),
-                          ),
-                          onSubmitted: (_) => _submit(),
-                          onChanged: (val) {
-                            if (_errorText != null) {
-                              setState(() {
-                                _errorText = null;
-                                _isShaking = false;
-                              });
-                            }
-                          },
-                        ),
-                        SizedBox(height: 32.h),
-                        
-                        // Action Buttons
-                        Row(
-                          mainAxisAlignment: widget.onCancel != null ? MainAxisAlignment.spaceBetween : MainAxisAlignment.center,
-                          children: [
-                            if (widget.onCancel != null)
-                              TextButton(
-                                onPressed: widget.onCancel,
-                                style: TextButton.styleFrom(
-                                  padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 12.h),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          // Glowing Icon
+                          Container(
+                            padding: const EdgeInsets.all(20),
+                            decoration: BoxDecoration(
+                              color: _isUnlocked 
+                                  ? Colors.greenAccent.withValues(alpha: 0.15) 
+                                  : appColors.primaryColor.withValues(alpha: 0.15),
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: _isUnlocked 
+                                      ? Colors.greenAccent.withValues(alpha: 0.3) 
+                                      : appColors.primaryColor.withValues(alpha: 0.3),
+                                  blurRadius: 20,
+                                  spreadRadius: 2,
+                                )
+                              ],
+                            ),
+                            child: Icon(
+                              _isUnlocked ? Icons.lock_open_rounded : Icons.lock_outline_rounded,
+                              size: 48,
+                              color: _isUnlocked ? Colors.greenAccent : appColors.primaryColor,
+                            )
+                            .animate(target: _isUnlocked ? 1 : 0)
+                            .scale(end: const Offset(1.1, 1.1))
+                            .tint(color: Colors.greenAccent),
+                          ).animate(onPlay: (controller) => controller.repeat(reverse: true))
+                           .shimmer(duration: 2500.ms, color: Colors.white.withValues(alpha: 0.3)),
+                          
+                          const SizedBox(height: 32),
+                          Text(
+                            widget.title,
+                            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.w800,
+                                  letterSpacing: -0.5,
                                 ),
-                                child: Text(
-                                  widget.cancelText ?? "Cancel", 
-                                  style: TextStyle(color: Theme.of(context).hintColor, fontWeight: FontWeight.w600),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            widget.message,
+                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                  color: Theme.of(context).hintColor,
+                                  height: 1.6,
+                                  fontSize: 15,
                                 ),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 40),
+                          
+                          // Premium Password Input
+                          Container(
+                            decoration: BoxDecoration(
+                              boxShadow: [
+                                BoxShadow(
+                                  color: appColors.primaryColor.withValues(alpha: 0.05),
+                                  blurRadius: 15,
+                                  offset: const Offset(0, 5),
+                                )
+                              ],
+                            ),
+                            child: TextField(
+                              controller: _controller,
+                              focusNode: _focusNode,
+                              obscureText: true,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(fontSize: 24, letterSpacing: 8.0, fontWeight: FontWeight.bold),
+                              decoration: InputDecoration(
+                                labelText: "Password",
+                                labelStyle: const TextStyle(letterSpacing: 0, fontSize: 14, fontWeight: FontWeight.normal),
+                                errorText: _errorText,
+                                errorStyle: const TextStyle(letterSpacing: 0, fontWeight: FontWeight.w500),
+                                filled: true,
+                                fillColor: appColors.inputBgFill,
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                  borderSide: BorderSide.none,
+                                ),
+                                enabledBorder: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                  borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1), width: 1),
+                                ),
+                                focusedBorder: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                  borderSide: BorderSide(color: appColors.primaryColor, width: 2),
+                                ),
+                                contentPadding: const EdgeInsets.symmetric(vertical: 20, horizontal: 20),
                               ),
-                            Expanded(
-                              flex: widget.onCancel != null ? 0 : 1,
-                              child: ElevatedButton(
-                                onPressed: _submit,
-                                style: ElevatedButton.styleFrom(
-                                  backgroundColor: appColors.primaryColor,
-                                  foregroundColor: Colors.white,
-                                  elevation: 0,
-                                  padding: EdgeInsets.symmetric(horizontal: 32.w, vertical: 14.h),
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12.r),
+                              onSubmitted: (_) => _submit(),
+                              onChanged: (val) {
+                                if (_errorText != null) {
+                                  setState(() {
+                                    _errorText = null;
+                                    _isShaking = false;
+                                  });
+                                }
+                              },
+                            ),
+                          ),
+                          const SizedBox(height: 40),
+                          
+                          // Action Buttons
+                          Row(
+                            mainAxisAlignment: widget.onCancel != null ? MainAxisAlignment.spaceBetween : MainAxisAlignment.center,
+                            children: [
+                              if (widget.onCancel != null)
+                                TextButton(
+                                  onPressed: widget.onCancel,
+                                  style: TextButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                  ),
+                                  child: Text(
+                                    widget.cancelText ?? "Cancel", 
+                                    style: TextStyle(color: Theme.of(context).hintColor, fontWeight: FontWeight.w600, fontSize: 16),
                                   ),
                                 ),
-                                child: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    Text("Unlock", style: TextStyle(fontSize: 16.sp, fontWeight: FontWeight.bold)),
-                                    SizedBox(width: 8.w),
-                                    const Icon(Icons.arrow_forward_rounded, size: 20),
-                                  ],
-                                ),
-                              ).animate(target: _isUnlocked ? 1 : 0).scale(end: const Offset(1.05, 1.05)),
-                            ),
-                          ],
-                        ),
-                      ],
+                              Expanded(
+                                flex: widget.onCancel != null ? 0 : 1,
+                                child: ElevatedButton(
+                                  onPressed: _submit,
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: appColors.primaryColor,
+                                    foregroundColor: Colors.white,
+                                    elevation: 5,
+                                    shadowColor: appColors.primaryColor.withValues(alpha: 0.5),
+                                    padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 18),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(16),
+                                    ),
+                                  ),
+                                  child: const Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text("Unlock", style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, letterSpacing: 0.5)),
+                                      SizedBox(width: 8),
+                                      Icon(Icons.arrow_forward_rounded, size: 20),
+                                    ],
+                                  ),
+                                ).animate(target: _isUnlocked ? 1 : 0).scale(end: const Offset(1.05, 1.05)),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ).animate()
-             .slideY(begin: 0.1, end: 0, duration: 400.ms, curve: Curves.easeOutCubic)
-             .fade(duration: 400.ms)
-             .animate(target: _isShaking ? 1 : 0, onComplete: (controller) => setState(() => _isShaking = false))
-             .shake(hz: 8, duration: 400.ms),
+              ).animate()
+               .slideY(begin: 0.1, end: 0, duration: 600.ms, curve: Curves.easeOutCubic)
+               .fade(duration: 600.ms)
+               .animate(target: _isShaking ? 1 : 0, onComplete: (controller) => setState(() => _isShaking = false))
+               .shake(hz: 8, duration: 400.ms),
+            ),
           ),
         ],
       ),

--- a/lib/features/scoreboard/data/mappers/scoreboard_mapper.dart
+++ b/lib/features/scoreboard/data/mappers/scoreboard_mapper.dart
@@ -1,5 +1,6 @@
 import 'package:scoreease/features/scoreboard/data/mappers/access_mapper.dart';
 import 'package:scoreease/features/scoreboard/data/models/scoreboard_model.dart';
+import 'package:scoreease/features/scoreboard/data/models/team_model.dart';
 import 'package:scoreease/features/scoreboard/domain/entities/scoreboard_entity.dart';
 
 class ScoreboardMapper {
@@ -14,6 +15,8 @@ class ScoreboardMapper {
       lastUpdated: model.lastUpdated != null ? DateTime.fromMillisecondsSinceEpoch(model.lastUpdated!) : null,
       access: model.access == null ? null : AccessMapper.toEntity(model.access!),
       players: model.players,
+      isTeamGame: model.isTeamGame,
+      teams: model.teams?.map((k, v) => MapEntry(k, v.toEntity())),
     );
   }
 
@@ -28,6 +31,8 @@ class ScoreboardMapper {
       lastUpdated: entity.lastUpdated?.millisecondsSinceEpoch,
       access: entity.access == null ? null : AccessMapper.fromEntity(entity.access!),
       players: entity.players,
+      isTeamGame: entity.isTeamGame,
+      teams: entity.teams?.map((k, v) => MapEntry(k, TeamModel.fromEntity(v))),
     );
   }
 }

--- a/lib/features/scoreboard/data/models/scoreboard_model.dart
+++ b/lib/features/scoreboard/data/models/scoreboard_model.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/foundation.dart';
 import 'package:scoreease/features/scoreboard/data/models/access_model.dart';
+import 'package:scoreease/features/scoreboard/data/models/team_model.dart';
 
 @immutable
 class ScoreboardModel {
@@ -16,6 +17,8 @@ class ScoreboardModel {
   final int? lastUpdated;
   final AccessModel? access;
   final Map<String, int>? players;
+  final bool? isTeamGame;
+  final Map<String, TeamModel>? teams;
 
   const ScoreboardModel({
     this.id,
@@ -27,11 +30,13 @@ class ScoreboardModel {
     this.lastUpdated,
     this.access,
     this.players,
+    this.isTeamGame,
+    this.teams,
   });
 
   @override
   String toString() {
-    return 'ScoreboardModel(id: $id, title: $title, description: $description, author: $author, ownerId: $ownerId, createdAt: $createdAt, lastUpdated: $lastUpdated, access: $access, players: $players)';
+    return 'ScoreboardModel(id: $id, title: $title, description: $description, author: $author, ownerId: $ownerId, createdAt: $createdAt, lastUpdated: $lastUpdated, access: $access, players: $players, isTeamGame: $isTeamGame, teams: $teams)';
   }
 
   factory ScoreboardModel.fromMap(Map<String, dynamic> data) {
@@ -45,6 +50,12 @@ class ScoreboardModel {
       lastUpdated: data['lastUpdated'] as int?,
       access: data['access'] == null ? null : AccessModel.fromMap(Map<String, dynamic>.from(data['access'] as Map)),
       players: data['players'] == null ? null : Map<String, int>.from(data['players'] as Map<dynamic, dynamic>),
+      isTeamGame: data['isTeamGame'] as bool?,
+      teams: data['teams'] == null
+          ? null
+          : (data['teams'] as Map).map(
+              (key, value) => MapEntry(key.toString(), TeamModel.fromMap(Map<String, dynamic>.from(value as Map))),
+            ),
     );
   }
 
@@ -58,6 +69,8 @@ class ScoreboardModel {
         'lastUpdated': ServerValue.timestamp,
         'access': access?.toMap(),
         'players': players,
+        'isTeamGame': isTeamGame,
+        'teams': teams?.map((k, v) => MapEntry(k, v.toMap())),
       };
 
   /// `dart:convert`
@@ -82,6 +95,8 @@ class ScoreboardModel {
     int? lastUpdated,
     AccessModel? access,
     Map<String, int>? players,
+    bool? isTeamGame,
+    Map<String, TeamModel>? teams,
   }) {
     return ScoreboardModel(
       id: id ?? this.id,
@@ -93,6 +108,8 @@ class ScoreboardModel {
       lastUpdated: lastUpdated ?? this.lastUpdated,
       access: access ?? this.access,
       players: players ?? this.players,
+      isTeamGame: isTeamGame ?? this.isTeamGame,
+      teams: teams ?? this.teams,
     );
   }
 

--- a/lib/features/scoreboard/data/models/team_model.dart
+++ b/lib/features/scoreboard/data/models/team_model.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/foundation.dart';
+import 'package:collection/collection.dart';
+import 'package:scoreease/features/scoreboard/domain/entities/team_entity.dart';
+
+@immutable
+class TeamModel {
+  final String name;
+  final Map<String, bool> players;
+
+  const TeamModel({
+    required this.name,
+    required this.players,
+  });
+
+  factory TeamModel.fromMap(Map<String, dynamic> data) {
+    return TeamModel(
+      name: data['name'] as String? ?? '',
+      players: data['players'] == null
+          ? {}
+          : Map<String, bool>.from(data['players'] as Map),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'players': players,
+      };
+
+  TeamModel copyWith({
+    String? name,
+    Map<String, bool>? players,
+  }) {
+    return TeamModel(
+      name: name ?? this.name,
+      players: players ?? this.players,
+    );
+  }
+
+  TeamEntity toEntity() {
+    return TeamEntity(name: name, players: players);
+  }
+
+  factory TeamModel.fromEntity(TeamEntity entity) {
+    return TeamModel(name: entity.name, players: entity.players);
+  }
+
+  @override
+  String toString() => 'TeamModel(name: $name, players: $players)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    final mapEquals = const DeepCollectionEquality().equals;
+    return other is TeamModel &&
+        other.name == name &&
+        mapEquals(other.players, players);
+  }
+
+  @override
+  int get hashCode => name.hashCode ^ const DeepCollectionEquality().hash(players);
+}

--- a/lib/features/scoreboard/domain/entities/scoreboard_entity.dart
+++ b/lib/features/scoreboard/domain/entities/scoreboard_entity.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import 'access_entity.dart';
+import 'team_entity.dart';
 
 @immutable
 class ScoreboardEntity {
@@ -13,6 +14,8 @@ class ScoreboardEntity {
   final DateTime? lastUpdated;
   final AccessEntity? access;
   final Map<String, int>? players;
+  final bool? isTeamGame;
+  final Map<String, TeamEntity>? teams;
 
   const ScoreboardEntity({
     this.id,
@@ -24,6 +27,8 @@ class ScoreboardEntity {
     this.lastUpdated,
     this.access,
     this.players,
+    this.isTeamGame,
+    this.teams,
   });
 
   ScoreboardEntity copyWith({
@@ -36,6 +41,8 @@ class ScoreboardEntity {
     DateTime? lastUpdated,
     AccessEntity? access,
     Map<String, int>? players,
+    bool? isTeamGame,
+    Map<String, TeamEntity>? teams,
   }) {
     return ScoreboardEntity(
       id: id ?? this.id,
@@ -47,12 +54,14 @@ class ScoreboardEntity {
       lastUpdated: lastUpdated ?? this.lastUpdated,
       access: access ?? this.access,
       players: players ?? this.players,
+      isTeamGame: isTeamGame ?? this.isTeamGame,
+      teams: teams ?? this.teams,
     );
   }
 
   @override
   String toString() {
-    return 'ScoreboardEntity(id: $id, title: $title, description: $description, author: $author, ownerId: $ownerId, createdAt: $createdAt, lastUpdated: $lastUpdated, access: $access, players: $players)';
+    return 'ScoreboardEntity(id: $id, title: $title, description: $description, author: $author, ownerId: $ownerId, createdAt: $createdAt, lastUpdated: $lastUpdated, access: $access, players: $players, isTeamGame: $isTeamGame, teams: $teams)';
   }
 
   @override

--- a/lib/features/scoreboard/domain/entities/team_entity.dart
+++ b/lib/features/scoreboard/domain/entities/team_entity.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class TeamEntity {
+  final String name;
+  final Map<String, bool> players;
+
+  const TeamEntity({
+    required this.name,
+    required this.players,
+  });
+
+  TeamEntity copyWith({
+    String? name,
+    Map<String, bool>? players,
+  }) {
+    return TeamEntity(
+      name: name ?? this.name,
+      players: players ?? this.players,
+    );
+  }
+
+  @override
+  String toString() => 'TeamEntity(name: $name, players: $players)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TeamEntity && other.name == name;
+  }
+
+  @override
+  int get hashCode => name.hashCode;
+}

--- a/lib/features/scoreboard/presentation/blocs/score_board_setup/score_board_setup_bloc.dart
+++ b/lib/features/scoreboard/presentation/blocs/score_board_setup/score_board_setup_bloc.dart
@@ -101,12 +101,22 @@ class ScoreboardSetupBloc extends Bloc<ScoreboardSetupEvent, ScoreboardSetupStat
           String errorTitle = "";
           String errorMessage = "";
 
-          if (event.scoreboardEntity.players?.isEmpty ?? true) {
-            errorTitle = MessageGenerator.getMessage("scoreboard-players-empty");
-            errorMessage = MessageGenerator.getMessage("scoreboard-players-empty-message");
-          } else if (event.scoreboardEntity.players?.keys.any((name) => name.isEmpty) ?? true) {
-            errorTitle = MessageGenerator.getMessage("scoreboard-players-empty-name");
-            errorMessage = MessageGenerator.getMessage("scoreboard-players-empty-name-message");
+          if (event.scoreboardEntity.isTeamGame == true) {
+            if ((event.scoreboardEntity.teams?.length ?? 0) < 2) {
+              errorTitle = "Not enough teams";
+              errorMessage = "A team game requires at least 2 teams.";
+            } else if (event.scoreboardEntity.teams?.values.any((team) => team.players.isEmpty) ?? false) {
+              errorTitle = "Empty teams";
+              errorMessage = "All teams must have at least one player.";
+            }
+          } else {
+            if (event.scoreboardEntity.players?.isEmpty ?? true) {
+              errorTitle = MessageGenerator.getMessage("scoreboard-players-empty");
+              errorMessage = MessageGenerator.getMessage("scoreboard-players-empty-message");
+            } else if (event.scoreboardEntity.players?.keys.any((name) => name.isEmpty) ?? true) {
+              errorTitle = MessageGenerator.getMessage("scoreboard-players-empty-name");
+              errorMessage = MessageGenerator.getMessage("scoreboard-players-empty-name-message");
+            }
           }
 
           if (errorTitle.isNotEmpty) {

--- a/lib/features/scoreboard/presentation/pages/score_board_setup_screen.dart
+++ b/lib/features/scoreboard/presentation/pages/score_board_setup_screen.dart
@@ -24,7 +24,9 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:scoreease/features/scoreboard/presentation/pages/widgets/scoreboard_setup_basic_stage.dart';
 import 'package:scoreease/features/scoreboard/presentation/pages/widgets/scoreboard_setup_roster_stage.dart';
+import 'package:scoreease/features/scoreboard/presentation/pages/widgets/scoreboard_setup_team_roster_stage.dart';
 import 'package:scoreease/features/scoreboard/presentation/pages/widgets/scoreboard_setup_access_stage.dart';
+import 'package:scoreease/features/scoreboard/domain/entities/team_entity.dart';
 import 'package:scoreease/core/utils/security_helper.dart';
 
 class ScoreboardSetupScreen extends StatefulWidget {
@@ -49,6 +51,8 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
   ScoreboardSetupStage _currentStage = ScoreboardSetupStage.basic;
   ScoreboardEntity _scoreboardEntity = const ScoreboardEntity();
   final List<String> _playerNameList = [];
+  bool _isTeamGame = false;
+  final Map<String, List<String>> _teamsMap = {};
 
   @override
   void initState() {
@@ -77,6 +81,20 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
           appLogger.e("Failed to decode draft players", error: e);
         }
       }
+
+      _isTeamGame = prefs.getBool('draft_setup_is_team_game') ?? false;
+      final teamsJson = prefs.getString('draft_setup_teams');
+      if (teamsJson != null) {
+        try {
+          final Map<String, dynamic> decoded = jsonDecode(teamsJson);
+          _teamsMap.clear();
+          decoded.forEach((key, value) {
+            _teamsMap[key] = (value as List).map((e) => e.toString()).toList();
+          });
+        } catch (e) {
+          appLogger.e("Failed to decode draft teams", error: e);
+        }
+      }
     });
   }
 
@@ -90,6 +108,8 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
     await prefs.setString('draft_setup_access_write', _scoreboardAccessWriteTextController.text);
     await prefs.setString('draft_setup_access_owner', _scoreboardAccessOwnerTextController.text);
     await prefs.setString('draft_setup_players', jsonEncode(_playerNameList));
+    await prefs.setBool('draft_setup_is_team_game', _isTeamGame);
+    await prefs.setString('draft_setup_teams', jsonEncode(_teamsMap));
     
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -134,6 +154,8 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
         await prefs.remove('draft_setup_access_write');
         await prefs.remove('draft_setup_access_owner');
         await prefs.remove('draft_setup_players');
+        await prefs.remove('draft_setup_is_team_game');
+        await prefs.remove('draft_setup_teams');
         
         setState(() {
           _scoreboardIdTextController.clear();
@@ -144,6 +166,8 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
           _scoreboardAccessWriteTextController.clear();
           _scoreboardAccessOwnerTextController.clear();
           _playerNameList.clear();
+          _isTeamGame = false;
+          _teamsMap.clear();
           _currentStage = ScoreboardSetupStage.basic;
         });
       },
@@ -403,9 +427,46 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
           titleController: _scoreboardTitleTextController,
           descriptionController: _scoreboardDescriptionTextController,
           authorController: _scoreboardAuthorTextController,
+          isTeamGame: _isTeamGame,
+          onGameModeChanged: (val) {
+            setState(() {
+              _isTeamGame = val;
+            });
+          },
           onNext: onScoreboardBasicNextButtonPressed,
         );
       case ScoreboardSetupStage.players:
+        if (_isTeamGame) {
+          return ScoreboardSetupTeamRosterStage(
+            teams: _teamsMap,
+            onAddTeam: (team) {
+              setState(() {
+                _teamsMap[team] = [];
+              });
+            },
+            onRemoveTeam: (team) {
+              setState(() {
+                _teamsMap.remove(team);
+              });
+            },
+            onAddPlayer: (team, player) {
+              setState(() {
+                _teamsMap[team]?.add(player);
+              });
+            },
+            onRemovePlayer: (team, player) {
+              setState(() {
+                _teamsMap[team]?.remove(player);
+              });
+            },
+            onNext: onScoreboardPlayerNamesNextButtonPressed,
+            onPrevious: () {
+              setState(() {
+                _currentStage = ScoreboardSetupStage.basic;
+              });
+            },
+          );
+        }
         return ScoreboardSetupRosterStage(
           players: _playerNameList,
           onAddPlayer: (player) {
@@ -448,6 +509,8 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
       author: _scoreboardAuthorTextController.text,
       ownerId: FirebaseAuth.instance.currentUser?.uid,
       players: const {},
+      isTeamGame: _isTeamGame,
+      teams: const {},
       access: const AccessEntity(
         read: "",
         write: "",
@@ -458,9 +521,30 @@ class _ScoreboardSetupScreenState extends State<ScoreboardSetupScreen> {
   }
 
   void onScoreboardPlayerNamesNextButtonPressed() {
-    _scoreboardEntity = _scoreboardEntity.copyWith(
-      players: _playerNameList.asMap().map((index, player) => MapEntry(player, 0)),
-    );
+    if (_isTeamGame) {
+      Map<String, int> allPlayers = {};
+      Map<String, TeamEntity> finalTeams = {};
+      _teamsMap.forEach((teamName, players) {
+        Map<String, bool> teamPlayersMap = {};
+        for (var p in players) {
+          allPlayers[p] = 0;
+          teamPlayersMap[p] = true;
+        }
+        finalTeams[teamName] = TeamEntity(name: teamName, players: teamPlayersMap);
+      });
+
+      _scoreboardEntity = _scoreboardEntity.copyWith(
+        players: allPlayers,
+        isTeamGame: true,
+        teams: finalTeams,
+      );
+    } else {
+      _scoreboardEntity = _scoreboardEntity.copyWith(
+        players: _playerNameList.asMap().map((index, player) => MapEntry(player, 0)),
+        isTeamGame: false,
+        teams: {},
+      );
+    }
     _bloc.add(ScoreboardSetupPlayerNamesSubmitEvent(_scoreboardEntity));
   }
 

--- a/lib/features/scoreboard/presentation/pages/scoreboard_editor_screen.dart
+++ b/lib/features/scoreboard/presentation/pages/scoreboard_editor_screen.dart
@@ -4,11 +4,13 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:go_router/go_router.dart';
 import 'package:loading_indicator/loading_indicator.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
+import 'package:scoreease/core/utils/constants.dart';
 
 import 'package:scoreease/core/utils/theme.dart';
 import 'package:scoreease/core/utils/widget_helper.dart';
 import 'package:scoreease/core/widgets/web_optimised_widget.dart';
 import 'package:scoreease/features/scoreboard/domain/entities/scoreboard_entity.dart';
+import 'package:scoreease/features/scoreboard/domain/entities/team_entity.dart';
 import 'package:scoreease/features/scoreboard/domain/entities/access_entity.dart';
 import 'package:scoreease/features/scoreboard/presentation/blocs/score_board_setup/score_board_setup_bloc.dart';
 import 'package:scoreease/features/scoreboard/presentation/pages/scoreboard_update_screen.dart';
@@ -44,6 +46,10 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
   bool _removeOwnerAccess = false;
   
   final Map<String, int> _playersMap = {};
+  final Map<String, TeamEntity> _teamsMap = {};
+  final TextEditingController _teamTextController = TextEditingController();
+  final Map<String, TextEditingController> _playerControllers = {};
+  final Map<String, FocusNode> _playerFocusNodes = {};
 
   ScoreboardEntity? _scoreboardEntity;
   bool _isOwnerUnlocked = false;
@@ -82,6 +88,9 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
     _writeAccessController = TextEditingController();
     _ownerAccessController = TextEditingController();
 
+    if (_scoreboardEntity!.teams != null) {
+      _teamsMap.addAll(_scoreboardEntity!.teams!);
+    }
     if (_scoreboardEntity!.players != null) {
       _playersMap.addAll(_scoreboardEntity!.players!);
     }
@@ -95,6 +104,13 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
     _readAccessController.dispose();
     _writeAccessController.dispose();
     _ownerAccessController.dispose();
+    _teamTextController.dispose();
+    for (var controller in _playerControllers.values) {
+      controller.dispose();
+    }
+    for (var node in _playerFocusNodes.values) {
+      node.dispose();
+    }
     _bloc.close();
     super.dispose();
   }
@@ -125,6 +141,7 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
       description: _descriptionController.text.trim(),
       author: _authorController.text.trim(),
       players: _playersMap,
+      teams: _scoreboardEntity!.isTeamGame == true ? _teamsMap : _scoreboardEntity!.teams,
       access: updatedAccess,
     );
 
@@ -158,6 +175,124 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
               }
             },
             child: Text("Add", style: TextStyle(color: appColors.buttonTextColor)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _addTeam() {
+    final newTeam = _teamTextController.text.trim();
+    if (newTeam.isNotEmpty) {
+      if (_teamsMap.containsKey(newTeam)) {
+        showSingleButtonAlertDialog(context: context, title: "Error", message: "Team already exists.");
+      } else {
+        setState(() {
+          _teamsMap[newTeam] = TeamEntity(name: newTeam, players: const {});
+        });
+        _teamTextController.clear();
+      }
+    }
+  }
+
+  void _removeTeam(String team) {
+    showTwoButtonAlertDialog(
+      context: context,
+      title: "Delete Team",
+      message: "Are you sure you want to delete $team and all its players?",
+      positiveButton: "Delete",
+      negativeButton: "Cancel",
+      positiveAction: () {
+        setState(() {
+          final teamData = _teamsMap[team];
+          if (teamData != null && teamData.players.isNotEmpty) {
+             for (var player in teamData.players.keys) {
+               _playersMap.remove(player);
+             }
+          }
+          _teamsMap.remove(team);
+        });
+      },
+    );
+  }
+
+  void _addPlayerToTeam(String teamName) {
+    if (!_playerControllers.containsKey(teamName)) return;
+    final controller = _playerControllers[teamName]!;
+    final newPlayer = controller.text.trim();
+    if (newPlayer.isNotEmpty) {
+      bool playerExists = _playersMap.containsKey(newPlayer);
+      if (playerExists) {
+        showSingleButtonAlertDialog(context: context, title: "Error", message: "Player already exists.");
+      } else {
+        setState(() {
+          _playersMap[newPlayer] = 0;
+          final team = _teamsMap[teamName]!;
+          final updatedPlayers = Map<String, bool>.from(team.players)..putIfAbsent(newPlayer, () => true);
+          _teamsMap[teamName] = team.copyWith(players: updatedPlayers);
+        });
+        controller.clear();
+      }
+    }
+  }
+
+  void _removePlayerFromTeam(String teamName, String player) {
+    showTwoButtonAlertDialog(
+      context: context,
+      title: "Delete Player",
+      message: "Are you sure you want to delete $player?",
+      positiveButton: "Delete",
+      negativeButton: "Cancel",
+      positiveAction: () {
+        setState(() {
+          _playersMap.remove(player);
+          final team = _teamsMap[teamName]!;
+          final updatedPlayers = Map<String, bool>.from(team.players)..remove(player);
+          _teamsMap[teamName] = team.copyWith(players: updatedPlayers);
+        });
+      },
+    );
+  }
+
+  void _editPlayerInTeam(String teamName, String oldPlayer) {
+    final controller = TextEditingController(text: oldPlayer);
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text("Edit Player Name", style: Theme.of(ctx).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.bold)),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(labelText: "New Player Name"),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text("Cancel")),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(backgroundColor: appColors.pleasantButtonBg),
+            onPressed: () {
+              final newName = controller.text.trim();
+              if (newName.isNotEmpty && newName != oldPlayer) {
+                if (_playersMap.containsKey(newName)) {
+                  showSingleButtonAlertDialog(context: context, title: "Error", message: "Player already exists.");
+                  return;
+                }
+                setState(() {
+                  final score = _playersMap[oldPlayer] ?? 0;
+                  _playersMap.remove(oldPlayer);
+                  _playersMap[newName] = score;
+
+                  final team = _teamsMap[teamName]!;
+                  final updatedPlayers = Map<String, bool>.from(team.players);
+                  updatedPlayers.remove(oldPlayer);
+                  updatedPlayers[newName] = true;
+                  _teamsMap[teamName] = team.copyWith(players: updatedPlayers);
+                });
+                Navigator.pop(ctx);
+              } else {
+                Navigator.pop(ctx);
+              }
+            },
+            child: Text("Save", style: TextStyle(color: appColors.buttonTextColor)),
           ),
         ],
       ),
@@ -237,6 +372,107 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
         ],
       ),
     );
+  }
+
+  Widget _buildTeamCard(String teamName, Map<String, bool> players) {
+    if (!_playerControllers.containsKey(teamName)) {
+      _playerControllers[teamName] = TextEditingController();
+      _playerFocusNodes[teamName] = FocusNode();
+    }
+
+    return Container(
+      margin: EdgeInsets.only(bottom: 16.h),
+      decoration: BoxDecoration(
+        color: Theme.of(context).scaffoldBackgroundColor.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(16.r),
+        border: Border.all(color: appColors.primaryColor.withValues(alpha: 0.05)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
+            decoration: BoxDecoration(
+              color: appColors.primaryColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(16.r),
+                topRight: Radius.circular(16.r),
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.shield, color: appColors.primaryColor, size: 20.sp),
+                    SizedBox(width: 8.w),
+                    Text(
+                      teamName,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline, color: Colors.red),
+                  onPressed: () => _removeTeam(teamName),
+                  tooltip: "Remove Team",
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.all(12.w),
+            child: Column(
+              children: [
+                getTextInputWidget(
+                  context: context,
+                  label: 'Add Player to $teamName',
+                  hint: 'Player Name',
+                  controller: _playerControllers[teamName]!,
+                  keyboardType: TextInputType.name,
+                  textInputAction: TextInputAction.go,
+                  prefixIcon: const Icon(Icons.person_add_alt_1_outlined),
+                  icon: Icons.add,
+                  focusNode: _playerFocusNodes[teamName],
+                  onPressed: () => _addPlayerToTeam(teamName),
+                ),
+                SizedBox(height: 12.h),
+                if (players.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(
+                      "No players in this team yet.",
+                      style: TextStyle(
+                        color: appColors.textColor.withValues(alpha: 0.5),
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  )
+                else
+                  Wrap(
+                    spacing: 8.0,
+                    runSpacing: 8.0,
+                    children: players.keys.map((player) {
+                      return InputChip(
+                        label: Text(player),
+                        onPressed: () => _editPlayerInTeam(teamName, player),
+                        deleteIcon: const Icon(Icons.cancel, size: 18),
+                        onDeleted: () => _removePlayerFromTeam(teamName, player),
+                        backgroundColor: appColors.screenBg,
+                        side: BorderSide(color: appColors.disableBgColor),
+                      ).animate().scale(duration: 200.ms, curve: Curves.easeOut);
+                    }).toList(),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ).animate().fade().slideY(begin: 0.1);
   }
 
   void _editPlayer(String oldName) {
@@ -381,11 +617,13 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
                 ),
               ],
             ),
-            body: Padding(
-              padding: WebOptimisedWidget.getWebOptimisedHorizonatalPadding().copyWith(left: 16, right: 16, top: 16),
-              child: ListView(
-                physics: const BouncingScrollPhysics(),
-                children: [
+            body: Center(
+              child: Container(
+                width: maxScreenWidth,
+                padding: WebOptimisedWidget.getWebOptimisedHorizonatalPadding().copyWith(left: 16, right: 16, top: 16),
+                child: ListView(
+                  physics: const BouncingScrollPhysics(),
+                  children: [
                   _buildSectionContainer(
                     title: "Basic Details",
                     icon: Icons.info_outline,
@@ -452,74 +690,107 @@ class _ScoreboardEditorScreenState extends State<ScoreboardEditorScreen> {
                     ],
                   ).animate().fade(duration: 400.ms, delay: 100.ms).slideY(begin: 0.1, curve: Curves.easeOutCubic),
 
-                  _buildSectionContainer(
-                    title: "Player Roster",
-                    icon: Icons.people_outline,
-                    action: TextButton.icon(
-                      icon: const Icon(Icons.add_circle_outline, size: 20),
-                      label: const Text("Add Player"),
-                      onPressed: _addPlayer,
-                      style: TextButton.styleFrom(foregroundColor: appColors.pleasantButtonBg),
-                    ),
-                    children: [
-                      if (_playersMap.isEmpty)
-                        Padding(
-                          padding: EdgeInsets.symmetric(vertical: 24.h),
-                          child: Center(
-                            child: Text(
-                              "No players added yet.",
-                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Theme.of(context).hintColor),
-                            ),
-                          ),
-                        )
-                      else
-                        ListView.separated(
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount: _playersMap.length,
-                          separatorBuilder: (context, index) => SizedBox(height: 8.h),
-                          itemBuilder: (context, index) {
-                            final player = _playersMap.keys.elementAt(index);
-                            return Container(
-                              decoration: BoxDecoration(
-                                color: Theme.of(context).scaffoldBackgroundColor.withValues(alpha: 0.5),
-                                borderRadius: BorderRadius.circular(12.r),
-                                border: Border.all(color: appColors.primaryColor.withValues(alpha: 0.05)),
-                              ),
-                              child: ListTile(
-                                leading: CircleAvatar(
-                                  backgroundColor: appColors.primaryColor.withValues(alpha: 0.1),
-                                  child: Text(player.isNotEmpty ? player[0].toUpperCase() : "?", style: TextStyle(color: appColors.primaryColor, fontWeight: FontWeight.bold)),
-                                ),
-                                title: Text(player, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
-                                subtitle: Text("Score: ${_playersMap[player]}", style: Theme.of(context).textTheme.bodySmall),
-                                trailing: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    IconButton(
-                                      icon: const Icon(Icons.edit_outlined, color: Colors.blue),
-                                      onPressed: () => _editPlayer(player),
-                                      tooltip: "Edit name",
-                                    ),
-                                    IconButton(
-                                      icon: const Icon(Icons.delete_outline, color: Colors.red),
-                                      onPressed: () => _deletePlayer(player),
-                                      tooltip: "Remove player",
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            );
-                          },
+                  if (_scoreboardEntity!.isTeamGame == true)
+                    _buildSectionContainer(
+                      title: "Team Roster",
+                      icon: Icons.group_work_outlined,
+                      children: [
+                        getTextInputWidget(
+                          context: context,
+                          label: 'Add Team',
+                          hint: 'e.g. Red Team',
+                          controller: _teamTextController,
+                          keyboardType: TextInputType.name,
+                          textInputAction: TextInputAction.go,
+                          prefixIcon: const Icon(Icons.group_add_outlined),
+                          icon: Icons.add,
+                          onPressed: _addTeam,
                         ),
-                    ],
-                  ).animate().fade(duration: 400.ms, delay: 200.ms).slideY(begin: 0.1, curve: Curves.easeOutCubic),
+                        SizedBox(height: 16.h),
+                        if (_teamsMap.isEmpty)
+                          Padding(
+                            padding: EdgeInsets.symmetric(vertical: 24.h),
+                            child: Center(
+                              child: Text(
+                                "No teams added yet.",
+                                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Theme.of(context).hintColor),
+                              ),
+                            ),
+                          )
+                        else
+                          ..._teamsMap.entries.map((entry) => _buildTeamCard(entry.key, entry.value.players)).toList(),
+                      ],
+                    ).animate().fade(duration: 400.ms, delay: 200.ms).slideY(begin: 0.1, curve: Curves.easeOutCubic)
+                  else
+                    _buildSectionContainer(
+                      title: "Player Roster",
+                      icon: Icons.people_outline,
+                      action: TextButton.icon(
+                        icon: const Icon(Icons.add_circle_outline, size: 20),
+                        label: const Text("Add Player"),
+                        onPressed: _addPlayer,
+                        style: TextButton.styleFrom(foregroundColor: appColors.pleasantButtonBg),
+                      ),
+                      children: [
+                        if (_playersMap.isEmpty)
+                          Padding(
+                            padding: EdgeInsets.symmetric(vertical: 24.h),
+                            child: Center(
+                              child: Text(
+                                "No players added yet.",
+                                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Theme.of(context).hintColor),
+                              ),
+                            ),
+                          )
+                        else
+                          ListView.separated(
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            itemCount: _playersMap.length,
+                            separatorBuilder: (context, index) => SizedBox(height: 8.h),
+                            itemBuilder: (context, index) {
+                              final player = _playersMap.keys.elementAt(index);
+                              return Container(
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).scaffoldBackgroundColor.withValues(alpha: 0.5),
+                                  borderRadius: BorderRadius.circular(12.r),
+                                  border: Border.all(color: appColors.primaryColor.withValues(alpha: 0.05)),
+                                ),
+                                child: ListTile(
+                                  leading: CircleAvatar(
+                                    backgroundColor: appColors.primaryColor.withValues(alpha: 0.1),
+                                    child: Text(player.isNotEmpty ? player[0].toUpperCase() : "?", style: TextStyle(color: appColors.primaryColor, fontWeight: FontWeight.bold)),
+                                  ),
+                                  title: Text(player, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
+                                  subtitle: Text("Score: ${_playersMap[player]}", style: Theme.of(context).textTheme.bodySmall),
+                                  trailing: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      IconButton(
+                                        icon: const Icon(Icons.edit_outlined, color: Colors.blue),
+                                        onPressed: () => _editPlayer(player),
+                                        tooltip: "Edit name",
+                                      ),
+                                      IconButton(
+                                        icon: const Icon(Icons.delete_outline, color: Colors.red),
+                                        onPressed: () => _deletePlayer(player),
+                                        tooltip: "Remove player",
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                      ],
+                    ).animate().fade(duration: 400.ms, delay: 200.ms).slideY(begin: 0.1, curve: Curves.easeOutCubic),
                   
                   SizedBox(height: 32.h),
                 ],
               ),
             ),
-      );
+          ),
+        );
         },
       ),
     );

--- a/lib/features/scoreboard/presentation/pages/scoreboard_score_display_screen.dart
+++ b/lib/features/scoreboard/presentation/pages/scoreboard_score_display_screen.dart
@@ -154,7 +154,11 @@ class _ScoreboardScoreDisplayScreenState extends State<ScoreboardScoreDisplayScr
                   ? Column(
                       children: [
                         _buildOverviewCard(),
-                        Expanded(child: getGridLayout(playersList)),
+                        Expanded(
+                          child: _scoreboardEntity?.isTeamGame == true
+                              ? _buildTeamLayout()
+                              : getGridLayout(playersList),
+                        ),
                       ],
                     )
                   : Center(
@@ -587,6 +591,133 @@ class _ScoreboardScoreDisplayScreenState extends State<ScoreboardScoreDisplayScr
         }
 
         return card;
+      },
+    );
+  }
+
+  Widget _buildTeamLayout() {
+    final teams = _scoreboardEntity?.teams;
+    if (teams == null || teams.isEmpty) return const SizedBox.shrink();
+
+    // Calculate team scores
+    final Map<String, int> teamScores = {};
+    for (var entry in teams.entries) {
+      int score = 0;
+      for (var player in entry.value.players.keys) {
+        score += _scoreboardEntity?.players?[player] ?? 0;
+      }
+      teamScores[entry.key] = score;
+    }
+
+    // Sort teams by score
+    final sortedTeams = teams.keys.toList();
+    sortedTeams.sort((a, b) => teamScores[b]!.compareTo(teamScores[a]!));
+
+    return ListView.builder(
+      physics: const BouncingScrollPhysics(),
+      itemCount: sortedTeams.length,
+      itemBuilder: (context, index) {
+        final teamName = sortedTeams[index];
+        final teamEntity = teams[teamName]!;
+        final teamTotalScore = teamScores[teamName]!;
+        
+        // Sort players within team
+        final teamPlayers = teamEntity.players.keys.toList();
+        teamPlayers.sort((a, b) {
+          final scoreA = _scoreboardEntity?.players?[a] ?? 0;
+          final scoreB = _scoreboardEntity?.players?[b] ?? 0;
+          int compare = scoreB.compareTo(scoreA);
+          if (compare != 0) return compare;
+          return a.compareTo(b);
+        });
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              margin: const EdgeInsets.only(top: 16, bottom: 8),
+              decoration: BoxDecoration(
+                color: appColors.primaryColor.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: appColors.primaryColor.withValues(alpha: 0.3)),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.shield, color: appColors.primaryColor),
+                      const SizedBox(width: 8),
+                      Text(
+                        teamName,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: appColors.primaryColor,
+                            ),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    teamTotalScore.toString(),
+                    key: ValueKey("team_${teamName}_$teamTotalScore"),
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: appColors.primaryColor,
+                        ),
+                  ).animate(key: ValueKey("team_${teamName}_$teamTotalScore")).scaleXY(
+                      begin: 1.5,
+                      end: 1.0,
+                      duration: 250.ms,
+                      curve: Curves.easeOutBack),
+                ],
+              ),
+            ),
+            GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: teamPlayers.length,
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 240,
+                childAspectRatio: 0.70,
+                mainAxisSpacing: 16,
+                crossAxisSpacing: 16,
+              ),
+              itemBuilder: (context, idx) {
+                String playerName = teamPlayers[idx];
+                String playerScore = _scoreboardEntity?.players?[playerName]?.toString() ?? '0';
+                
+                // Rank logic for display screen
+                // Use global rank or team rank? Let's use global rank for now.
+                final globalScoreSortedList = List<String>.from(_scoreboardEntity?.players?.keys ?? <String>[]);
+                globalScoreSortedList.sort((a, b) {
+                  final scoreA = _scoreboardEntity?.players?[a] ?? 0;
+                  final scoreB = _scoreboardEntity?.players?[b] ?? 0;
+                  int compare = scoreB.compareTo(scoreA);
+                  if (compare != 0) return compare;
+                  return a.compareTo(b);
+                });
+                int rank = globalScoreSortedList.indexOf(playerName) + 1;
+                
+                bool rankChanged = _previousRanks.isNotEmpty && _previousRanks[playerName] != _currentRanks[playerName];
+                Widget card = _buildPlayerCard(playerName, playerScore, rank);
+
+                if (rankChanged) {
+                   card = card.animate(key: ValueKey('rank_change_${_currentRanks[playerName]}_$playerName'))
+                       .shimmer(duration: 800.ms, color: Colors.amber.withValues(alpha: 0.5))
+                       .scaleXY(begin: 1.0, end: 1.05, duration: 300.ms, curve: Curves.easeOutBack)
+                       .then()
+                       .scaleXY(begin: 1.05, end: 1.0, duration: 300.ms, curve: Curves.easeIn);
+                } else {
+                   card = card.animate(key: ValueKey('fade_in_$playerName')).fade().slideY(begin: 0.2, curve: Curves.easeOut);
+                }
+
+                return card;
+              },
+            ),
+            const SizedBox(height: 16),
+          ],
+        );
       },
     );
   }

--- a/lib/features/scoreboard/presentation/pages/scoreboard_update_screen.dart
+++ b/lib/features/scoreboard/presentation/pages/scoreboard_update_screen.dart
@@ -180,7 +180,9 @@ class _ScoreboardScoreUpdateScreenState
                   _buildSearchBar(),
                   Expanded(
                     child: playersList.isNotEmpty
-                        ? getGridLayout(playersList)
+                        ? (_scoreboardEntity?.isTeamGame == true
+                            ? _buildTeamLayout()
+                            : getGridLayout(playersList))
                         : Center(
                             child: Padding(
                               padding: const EdgeInsets.all(24.0),
@@ -690,6 +692,95 @@ class _ScoreboardScoreUpdateScreenState
         String playerScore =
             _scoreboardEntity?.players?[playerName]?.toString() ?? '0';
         return _buildPlayerCard(playerName, playerScore);
+      },
+    );
+  }
+
+  Widget _buildTeamLayout() {
+    final teams = _scoreboardEntity?.teams;
+    if (teams == null || teams.isEmpty) return const SizedBox.shrink();
+
+    return ListView.builder(
+      physics: const BouncingScrollPhysics(),
+      itemCount: teams.length,
+      itemBuilder: (context, index) {
+        final teamEntity = teams.values.elementAt(index);
+        final teamName = teamEntity.name;
+        
+        final filteredPlayers = teamEntity.players.keys
+            .where((player) =>
+                player.toLowerCase().contains(_searchQuery.toLowerCase()))
+            .toList();
+
+        if (filteredPlayers.isEmpty) return const SizedBox.shrink();
+
+        int teamTotalScore = 0;
+        for (var p in teamEntity.players.keys) {
+          teamTotalScore += _scoreboardEntity?.players?[p] ?? 0;
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              margin: const EdgeInsets.only(top: 16, bottom: 8),
+              decoration: BoxDecoration(
+                color: appColors.primaryColor.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: appColors.primaryColor.withValues(alpha: 0.3)),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.shield, color: appColors.primaryColor),
+                      const SizedBox(width: 8),
+                      Text(
+                        teamName,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: appColors.primaryColor,
+                            ),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    teamTotalScore.toString(),
+                    key: ValueKey("team_${teamName}_$teamTotalScore"),
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: appColors.primaryColor,
+                        ),
+                  ).animate(key: ValueKey("team_${teamName}_$teamTotalScore")).scaleXY(
+                      begin: 1.5,
+                      end: 1.0,
+                      duration: 250.ms,
+                      curve: Curves.easeOutBack),
+                ],
+              ),
+            ),
+            GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: filteredPlayers.length,
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 220,
+                childAspectRatio: 0.82,
+                mainAxisSpacing: 16,
+                crossAxisSpacing: 16,
+              ),
+              itemBuilder: (context, idx) {
+                String playerName = filteredPlayers[idx];
+                String playerScore =
+                    _scoreboardEntity?.players?[playerName]?.toString() ?? '0';
+                return _buildPlayerCard(playerName, playerScore);
+              },
+            ),
+            const SizedBox(height: 16),
+          ],
+        );
       },
     );
   }

--- a/lib/features/scoreboard/presentation/pages/widgets/scoreboard_setup_basic_stage.dart
+++ b/lib/features/scoreboard/presentation/pages/widgets/scoreboard_setup_basic_stage.dart
@@ -12,6 +12,8 @@ class ScoreboardSetupBasicStage extends StatelessWidget {
   final TextEditingController titleController;
   final TextEditingController descriptionController;
   final TextEditingController authorController;
+  final bool isTeamGame;
+  final ValueChanged<bool> onGameModeChanged;
   final VoidCallback onNext;
 
   const ScoreboardSetupBasicStage({
@@ -20,6 +22,8 @@ class ScoreboardSetupBasicStage extends StatelessWidget {
     required this.titleController,
     required this.descriptionController,
     required this.authorController,
+    required this.isTeamGame,
+    required this.onGameModeChanged,
     required this.onNext,
   }) : super(key: key);
 
@@ -88,7 +92,9 @@ class ScoreboardSetupBasicStage extends StatelessWidget {
             LengthLimitingTextInputFormatter(20),
           ],
         ),
-        SizedBox(height: 8.h),
+        SizedBox(height: 16.h),
+        _buildGameModeToggle(context),
+        SizedBox(height: 16.h),
         Row(
           children: [
             Expanded(
@@ -111,6 +117,90 @@ class ScoreboardSetupBasicStage extends StatelessWidget {
         ),
         SizedBox(height: 16.h),
       ],
+    );
+  }
+
+  Widget _buildGameModeToggle(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 8.0),
+          child: Text(
+            "Game Mode",
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: appColors.primaryColor,
+                ),
+          ),
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: _buildModeOption(
+                context,
+                title: "Individual",
+                icon: Icons.person_outline,
+                isSelected: !isTeamGame,
+                onTap: () => onGameModeChanged(false),
+              ),
+            ),
+            SizedBox(width: 12.w),
+            Expanded(
+              child: _buildModeOption(
+                context,
+                title: "Team vs Team",
+                icon: Icons.groups_outlined,
+                isSelected: isTeamGame,
+                onTap: () => onGameModeChanged(true),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildModeOption(BuildContext context, {
+    required String title,
+    required IconData icon,
+    required bool isSelected,
+    required VoidCallback onTap,
+  }) {
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        onTap();
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? appColors.primaryColor.withValues(alpha: 0.1) : appColors.inputBgFill,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: isSelected ? appColors.primaryColor : Colors.transparent,
+            width: 2,
+          ),
+        ),
+        child: Column(
+          children: [
+            Icon(
+              icon,
+              size: 32.sp,
+              color: isSelected ? appColors.primaryColor : appColors.disableBgColor,
+            ),
+            SizedBox(height: 8.h),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                    color: isSelected ? appColors.primaryColor : appColors.textColor,
+                  ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/scoreboard/presentation/pages/widgets/scoreboard_setup_team_roster_stage.dart
+++ b/lib/features/scoreboard/presentation/pages/widgets/scoreboard_setup_team_roster_stage.dart
@@ -1,0 +1,293 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:scoreease/core/utils/theme.dart';
+import 'package:scoreease/core/utils/widget_helper.dart';
+import 'package:scoreease/core/widgets/animated_container.dart';
+
+class ScoreboardSetupTeamRosterStage extends StatefulWidget {
+  final Map<String, List<String>> teams;
+  final ValueChanged<String> onAddTeam;
+  final ValueChanged<String> onRemoveTeam;
+  final void Function(String team, String player) onAddPlayer;
+  final void Function(String team, String player) onRemovePlayer;
+  final VoidCallback onNext;
+  final VoidCallback onPrevious;
+
+  const ScoreboardSetupTeamRosterStage({
+    Key? key,
+    required this.teams,
+    required this.onAddTeam,
+    required this.onRemoveTeam,
+    required this.onAddPlayer,
+    required this.onRemovePlayer,
+    required this.onNext,
+    required this.onPrevious,
+  }) : super(key: key);
+
+  @override
+  State<ScoreboardSetupTeamRosterStage> createState() =>
+      _ScoreboardSetupTeamRosterStageState();
+}
+
+class _ScoreboardSetupTeamRosterStageState
+    extends State<ScoreboardSetupTeamRosterStage> {
+  final TextEditingController _teamTextController = TextEditingController();
+  late FocusNode _teamFocusNode;
+  final Map<String, TextEditingController> _playerControllers = {};
+  final Map<String, FocusNode> _playerFocusNodes = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _teamFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _teamTextController.dispose();
+    _teamFocusNode.dispose();
+    for (var controller in _playerControllers.values) {
+      controller.dispose();
+    }
+    for (var node in _playerFocusNodes.values) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SizedBox(height: 8.h),
+        getTextInputWidget(
+          context: context,
+          label: 'Add Team',
+          hint: 'e.g. Red Team',
+          controller: _teamTextController,
+          keyboardType: TextInputType.name,
+          textInputAction: TextInputAction.go,
+          prefixIcon: const Icon(Icons.group_add_outlined),
+          inputFormatters: [
+            LengthLimitingTextInputFormatter(20),
+          ],
+          icon: Icons.add,
+          focusNode: _teamFocusNode,
+          onPressed: () {
+            final newTeam = _teamTextController.text.trim();
+            if (newTeam.isNotEmpty) {
+              if (widget.teams.containsKey(newTeam)) {
+                showSingleButtonAlertDialog(
+                  context: context,
+                  title: 'Duplicate Team',
+                  message: 'Team "$newTeam" is already added!',
+                );
+              } else {
+                HapticFeedback.lightImpact();
+                widget.onAddTeam(newTeam);
+                _teamTextController.clear();
+              }
+            }
+            _teamFocusNode.requestFocus();
+          },
+        ),
+        SizedBox(height: 16.h),
+        if (widget.teams.isEmpty)
+          Column(
+            children: [
+              Icon(Icons.sports_kabaddi,
+                      size: 48.sp,
+                      color: appColors.textColor.withValues(alpha: 0.3))
+                  .animate(
+                      onPlay: (controller) => controller.repeat(reverse: true))
+                  .slideY(
+                      begin: -0.2,
+                      end: 0.2,
+                      duration: 1.seconds,
+                      curve: Curves.easeInOutSine),
+              SizedBox(height: 16.h),
+              Text(
+                "No teams added yet. Add at least 2 teams to continue.",
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: appColors.textColor.withValues(alpha: 0.6),
+                    ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          )
+        else
+          ...widget.teams.entries.map((entry) => _buildTeamCard(entry.key, entry.value)).toList(),
+        SizedBox(height: 16.h),
+        Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: AnimatedClickableTextContainer(
+                  title: '⟵ Back',
+                  iconSrc: '',
+                  isActive: false,
+                  bgColor: appColors.inputBgFill,
+                  bgColorHover: appColors.sideMenuHighlight,
+                  textColor: appColors.textColor,
+                  textColorHover: Theme.of(context).brightness == Brightness.light
+                      ? Colors.white
+                      : Colors.black,
+                  press: () {
+                    HapticFeedback.lightImpact();
+                    widget.onPrevious();
+                  },
+                ),
+              ),
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: AnimatedClickableTextContainer(
+                  title: 'Next: Set Access ➔',
+                  iconSrc: '',
+                  isActive: false,
+                  bgColor: appColors.pleasantButtonBg,
+                  bgColorHover: appColors.pleasantButtonBgHover,
+                  press: () {
+                    HapticFeedback.lightImpact();
+                    widget.onNext();
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: 16.h),
+      ],
+    );
+  }
+
+  Widget _buildTeamCard(String teamName, List<String> players) {
+    if (!_playerControllers.containsKey(teamName)) {
+      _playerControllers[teamName] = TextEditingController();
+      _playerFocusNodes[teamName] = FocusNode();
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        color: appColors.tileBgColor,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: appColors.tileBgColorHover, width: 2),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            decoration: BoxDecoration(
+              color: appColors.primaryColor.withValues(alpha: 0.1),
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(14),
+                topRight: Radius.circular(14),
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.shield, color: appColors.primaryColor),
+                    const SizedBox(width: 8),
+                    Text(
+                      teamName,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline, color: Colors.red),
+                  onPressed: () {
+                    HapticFeedback.lightImpact();
+                    widget.onRemoveTeam(teamName);
+                  },
+                  tooltip: "Remove Team",
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              children: [
+                getTextInputWidget(
+                  context: context,
+                  label: 'Add Player to $teamName',
+                  hint: 'Player Name',
+                  controller: _playerControllers[teamName]!,
+                  keyboardType: TextInputType.name,
+                  textInputAction: TextInputAction.go,
+                  prefixIcon: const Icon(Icons.person_add_alt_1_outlined),
+                  icon: Icons.add,
+                  focusNode: _playerFocusNodes[teamName],
+                  onPressed: () {
+                    final newPlayer = _playerControllers[teamName]!.text.trim();
+                    if (newPlayer.isNotEmpty) {
+                      bool playerExists = widget.teams.values
+                          .expand((p) => p)
+                          .contains(newPlayer);
+                      if (playerExists) {
+                        showSingleButtonAlertDialog(
+                          context: context,
+                          title: 'Duplicate Player',
+                          message: 'Player "$newPlayer" is already in a team!',
+                        );
+                      } else {
+                        HapticFeedback.lightImpact();
+                        widget.onAddPlayer(teamName, newPlayer);
+                        _playerControllers[teamName]!.clear();
+                      }
+                    }
+                    _playerFocusNodes[teamName]!.requestFocus();
+                  },
+                ),
+                const SizedBox(height: 12),
+                if (players.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(
+                      "No players in this team yet.",
+                      style: TextStyle(
+                        color: appColors.textColor.withValues(alpha: 0.5),
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  )
+                else
+                  Wrap(
+                    spacing: 8.0,
+                    runSpacing: 8.0,
+                    children: players.map((player) {
+                      return Chip(
+                        label: Text(player),
+                        deleteIcon: const Icon(Icons.cancel, size: 18),
+                        onDeleted: () {
+                          HapticFeedback.lightImpact();
+                          widget.onRemovePlayer(teamName, player);
+                        },
+                        backgroundColor: appColors.screenBg,
+                        side: BorderSide(color: appColors.disableBgColor),
+                      ).animate().scale(duration: 200.ms, curve: Curves.easeOut);
+                    }).toList(),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ).animate().fade().slideY(begin: 0.1);
+  }
+}

--- a/lib/features/settings/presentation/pages/settings_screen.dart
+++ b/lib/features/settings/presentation/pages/settings_screen.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:scoreease/core/utils/constants.dart';
 import 'package:scoreease/core/utils/theme.dart';
 import 'package:scoreease/core/utils/version_story.dart';
 import 'package:scoreease/core/utils/widget_helper.dart';
@@ -40,7 +39,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: Center(
         child: Container(
           padding: WebOptimisedWidget.getWebOptimisedHorizonatalPadding(),
-          width: maxScreenWidth,
           child: ListView.builder(
             padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
             itemCount: items.length,
@@ -50,7 +48,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
               if (isHeader) {
                 return Padding(
-                  padding: EdgeInsets.only(top: index == 0 ? 0 : 24.h, bottom: 12.h, left: 8.w),
+                  padding: EdgeInsets.only(
+                      top: index == 0 ? 0 : 24.h, bottom: 12.h, left: 8.w),
                   child: Text(
                     item.title.toUpperCase(),
                     style: Theme.of(context).textTheme.labelMedium?.copyWith(
@@ -59,13 +58,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           letterSpacing: 1.2,
                         ),
                   ),
-                ).animate().fade(duration: 400.ms, delay: (40 * index).ms).slideX(begin: 0.05, end: 0);
+                )
+                    .animate()
+                    .fade(duration: 400.ms, delay: (40 * index).ms)
+                    .slideX(begin: 0.05, end: 0);
               }
 
               return Padding(
                 padding: EdgeInsets.only(bottom: 12.h),
                 child: SettingsListItem(item: item),
-              ).animate().fade(duration: 400.ms, delay: (40 * index).ms).slideY(begin: 0.1, end: 0);
+              )
+                  .animate()
+                  .fade(duration: 400.ms, delay: (40 * index).ms)
+                  .slideY(begin: 0.1, end: 0);
             },
           ),
         ),
@@ -206,7 +211,7 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
           return Text(
             display,
             style: appTheme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w600, 
+              fontWeight: FontWeight.w600,
               color: appColors.primaryColor,
             ),
           );
@@ -239,8 +244,8 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
                   Text(
                     "Choose Theme",
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
                   SizedBox(height: 16.h),
                   ListTile(
@@ -289,7 +294,8 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
         showTwoButtonAlertDialog(
           context: context,
           title: "Clear Passwords",
-          message: "Are you sure you want to clear all locally saved scoreboard accesses? You will have to enter passwords again.",
+          message:
+              "Are you sure you want to clear all locally saved scoreboard accesses? You will have to enter passwords again.",
           positiveButton: "Clear",
           negativeButton: "Cancel",
           positiveAction: () async {
@@ -297,7 +303,8 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: const Text("All saved passwords cleared successfully!"),
+                  content:
+                      const Text("All saved passwords cleared successfully!"),
                   behavior: SnackBarBehavior.floating,
                   backgroundColor: appColors.pleasantButtonBg,
                   duration: const Duration(seconds: 2),
@@ -323,8 +330,9 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
         builder: (context, snapshot) {
           versionStory = snapshot.data;
           return Text(
-            versionStory?.versionDisplay ?? '-', 
-            style: appTheme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600, color: appColors.primaryColor),
+            versionStory?.versionDisplay ?? '-',
+            style: appTheme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600, color: appColors.primaryColor),
           );
         },
       ),
@@ -339,7 +347,8 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
       icon: Icons.bug_report_rounded,
       iconColor: Colors.orangeAccent,
       onTap: () {
-        launchUrl(Uri.parse('https://github.com/midhunarmid/scoreease/issues/new?template=bug_report.md'));
+        launchUrl(Uri.parse(
+            'https://github.com/midhunarmid/scoreease/issues/new?template=bug_report.md'));
       },
       type: SettingsItemType.link,
     ),
@@ -349,7 +358,8 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
       icon: Icons.lightbulb_outline_rounded,
       iconColor: Colors.amber,
       onTap: () {
-        launchUrl(Uri.parse('https://github.com/midhunarmid/scoreease/issues/new?template=feature_request.md'));
+        launchUrl(Uri.parse(
+            'https://github.com/midhunarmid/scoreease/issues/new?template=feature_request.md'));
       },
       type: SettingsItemType.link,
     ),
@@ -359,7 +369,8 @@ List<SettingsItem> getSettingsItems(BuildContext context) {
       icon: Icons.people_outline_rounded,
       iconColor: Colors.tealAccent,
       onTap: () {
-        launchUrl(Uri.parse('https://github.com/midhunarmid/scoreease/graphs/contributors'));
+        launchUrl(Uri.parse(
+            'https://github.com/midhunarmid/scoreease/graphs/contributors'));
       },
       type: SettingsItemType.link,
     ),

--- a/lib/features/settings/presentation/pages/version_history_screen.dart
+++ b/lib/features/settings/presentation/pages/version_history_screen.dart
@@ -6,7 +6,6 @@ import 'package:scoreease/core/utils/theme.dart';
 import 'package:scoreease/core/utils/version_story.dart';
 import 'package:scoreease/core/widgets/web_optimised_widget.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:scoreease/core/utils/constants.dart';
 
 class VersionHistoryScreen extends StatelessWidget {
   static const routeName = 'version_history';
@@ -29,26 +28,32 @@ class VersionHistoryScreen extends StatelessWidget {
           if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
-          final currentBuildNumber = int.tryParse(snapshot.data!.buildNumber) ?? 0;
+          final currentBuildNumber =
+              int.tryParse(snapshot.data!.buildNumber) ?? 0;
 
           // Split and sort keys
           final allKeys = ScoreEaseVersionStory.versionStoryMap.keys.toList()
             ..sort((a, b) => int.parse(b).compareTo(int.parse(a)));
-          
-          final futureKeys = allKeys.where((k) => int.parse(k) > currentBuildNumber).toList();
-          final pastKeys = allKeys.where((k) => int.parse(k) <= currentBuildNumber).toList();
+
+          final futureKeys =
+              allKeys.where((k) => int.parse(k) > currentBuildNumber).toList();
+          final pastKeys =
+              allKeys.where((k) => int.parse(k) <= currentBuildNumber).toList();
 
           return Center(
             child: Container(
               padding: WebOptimisedWidget.getWebOptimisedHorizonatalPadding(),
-              width: maxScreenWidth,
               child: ListView(
                 padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 24.h),
                 children: [
                   if (futureKeys.isNotEmpty) ...[
-                    _buildRoadmapHeader(context).animate().fade(duration: 500.ms).slideY(begin: 0.1, end: 0),
+                    _buildRoadmapHeader(context)
+                        .animate()
+                        .fade(duration: 500.ms)
+                        .slideY(begin: 0.1, end: 0),
                     ...List.generate(futureKeys.length, (index) {
-                      final version = ScoreEaseVersionStory.versionStoryMap[futureKeys[index]]!;
+                      final version = ScoreEaseVersionStory
+                          .versionStoryMap[futureKeys[index]]!;
                       return _buildRoadmapNode(context, version)
                           .animate()
                           .fade(duration: 500.ms, delay: (100 * (index + 1)).ms)
@@ -57,11 +62,14 @@ class VersionHistoryScreen extends StatelessWidget {
                     SizedBox(height: 16.h),
                   ],
                   ...List.generate(pastKeys.length, (index) {
-                    final version = ScoreEaseVersionStory.versionStoryMap[pastKeys[index]]!;
+                    final version =
+                        ScoreEaseVersionStory.versionStoryMap[pastKeys[index]]!;
                     final isLast = index == pastKeys.length - 1;
                     return _buildVersionNode(context, version, isLast)
                         .animate()
-                        .fade(duration: 500.ms, delay: (100 * (futureKeys.length + index + 1)).ms)
+                        .fade(
+                            duration: 500.ms,
+                            delay: (100 * (futureKeys.length + index + 1)).ms)
                         .slideY(begin: 0.1, end: 0);
                   }),
                 ],
@@ -87,7 +95,8 @@ class VersionHistoryScreen extends StatelessWidget {
               shape: BoxShape.circle,
               border: Border.all(color: Colors.amber, width: 2),
             ),
-            child: Icon(Icons.rocket_launch_rounded, size: 14.w, color: Colors.amber),
+            child: Icon(Icons.rocket_launch_rounded,
+                size: 14.w, color: Colors.amber),
           ),
         ),
         SizedBox(width: 8.w),
@@ -119,7 +128,8 @@ class VersionHistoryScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildRoadmapNode(BuildContext context, ScoreEaseVersionStory version) {
+  Widget _buildRoadmapNode(
+      BuildContext context, ScoreEaseVersionStory version) {
     return Stack(
       children: [
         // Dashed line
@@ -138,7 +148,8 @@ class VersionHistoryScreen extends StatelessWidget {
                     width: 2,
                     height: 3,
                     child: DecoratedBox(
-                      decoration: BoxDecoration(color: Colors.amber.withValues(alpha: 0.5)),
+                      decoration: BoxDecoration(
+                          color: Colors.amber.withValues(alpha: 0.5)),
                     ),
                   ),
                 ),
@@ -149,7 +160,8 @@ class VersionHistoryScreen extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(width: 40.w), // Empty space for dashed line to pass through
+            SizedBox(
+                width: 40.w), // Empty space for dashed line to pass through
             SizedBox(width: 8.w),
             // Content Card
             Expanded(
@@ -177,14 +189,20 @@ class VersionHistoryScreen extends StatelessWidget {
                             children: [
                               Text(
                                 "v${version.versionSemantic} ${version.versionName}",
-                                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium
+                                    ?.copyWith(
                                       fontWeight: FontWeight.bold,
                                       color: Colors.amber.shade700,
                                     ),
                               ),
                               Text(
                                 "Planned",
-                                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .labelSmall
+                                    ?.copyWith(
                                       color: Colors.amber,
                                       fontStyle: FontStyle.italic,
                                     ),
@@ -194,13 +212,18 @@ class VersionHistoryScreen extends StatelessWidget {
                           SizedBox(height: 8.h),
                           Text(
                             version.tagline,
-                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
                                   fontStyle: FontStyle.italic,
                                   color: Colors.amber,
                                 ),
                           ),
                           SizedBox(height: 12.h),
-                          ...version.features.map((feature) => _buildFeatureBullet(context, feature, color: Colors.amber)),
+                          ...version.features.map((feature) =>
+                              _buildFeatureBullet(context, feature,
+                                  color: Colors.amber)),
                         ],
                       ),
                     ),
@@ -214,7 +237,8 @@ class VersionHistoryScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildVersionNode(BuildContext context, ScoreEaseVersionStory version, bool isLast) {
+  Widget _buildVersionNode(
+      BuildContext context, ScoreEaseVersionStory version, bool isLast) {
     return Stack(
       children: [
         if (!isLast)
@@ -277,13 +301,19 @@ class VersionHistoryScreen extends StatelessWidget {
                             children: [
                               Text(
                                 "v${version.versionSemantic} ${version.versionName}",
-                                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium
+                                    ?.copyWith(
                                       fontWeight: FontWeight.bold,
                                     ),
                               ),
                               Text(
                                 version.buildDate,
-                                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .labelSmall
+                                    ?.copyWith(
                                       color: Theme.of(context).hintColor,
                                     ),
                               ),
@@ -292,13 +322,17 @@ class VersionHistoryScreen extends StatelessWidget {
                           SizedBox(height: 8.h),
                           Text(
                             version.tagline,
-                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
                                   fontStyle: FontStyle.italic,
                                   color: appColors.primaryColor,
                                 ),
                           ),
                           SizedBox(height: 12.h),
-                          ...version.features.map((feature) => _buildFeatureBullet(context, feature)),
+                          ...version.features.map((feature) =>
+                              _buildFeatureBullet(context, feature)),
                         ],
                       ),
                     ),
@@ -312,7 +346,8 @@ class VersionHistoryScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildFeatureBullet(BuildContext context, String text, {Color? color}) {
+  Widget _buildFeatureBullet(BuildContext context, String text,
+      {Color? color}) {
     return Padding(
       padding: EdgeInsets.only(bottom: 6.h),
       child: Row(
@@ -322,13 +357,15 @@ class VersionHistoryScreen extends StatelessWidget {
             padding: EdgeInsets.only(top: 6.h, right: 8.w),
             child: CircleAvatar(
               radius: 3,
-              backgroundColor: color ?? appColors.textColor.withValues(alpha: 0.5),
+              backgroundColor:
+                  color ?? appColors.textColor.withValues(alpha: 0.5),
             ),
           ),
           Expanded(
             child: Text(
               text,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(height: 1.4),
+              style:
+                  Theme.of(context).textTheme.bodySmall?.copyWith(height: 1.4),
             ),
           ),
         ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: scoreease
 description: Track. Update. Share. Score with Ease.
 publish_to: 'none'
-version: 1.3.0+4
+version: 1.4.0+5
 
 environment:
   sdk: '>=3.0.6 <4.0.0'


### PR DESCRIPTION
### Overview
This PR introduces comprehensive support for Team Games in ScoreEase, allowing users to create scoreboards with multiple teams and group players accordingly.

**Key Changes**

1. Core Entities: Introduced TeamEntity and updated ScoreboardEntity to support the isTeamGame flag and a teams mapping. Data models and mappers were updated to reflect this new schema.
2. Scoreboard Setup: Added the ScoreboardSetupTeamRosterStage widget to handle the creation of teams and allocation of players during the setup wizard.
3. Scoreboard Editor: Fully refactored ScoreboardEditorScreen to seamlessly manage existing team games. Scoreboard owners can now view team rosters, edit team names, add/remove players from teams, and delete entire teams dynamically.
4. Scoreboard Display/Update: Adjusted the UI in ScoreboardUpdateScreen and ScoreboardScoreDisplayScreen to correctly calculate and display grouped team scores alongside individual player metrics.
5. UI & Layout Fixes: Enhanced the visual layout across multiple screens (including Settings and Password Prompts) with constraints (maxScreenWidth) to improve presentation on Desktop and Web environments.